### PR TITLE
Improvement

### DIFF
--- a/SwiftyCodeView/Classes/SwiftyCodeView/SwiftyCodeView.swift
+++ b/SwiftyCodeView/Classes/SwiftyCodeView/SwiftyCodeView.swift
@@ -9,6 +9,7 @@ import UIKit
 @objc
 public protocol SwiftyCodeViewDelegate: class {
 	func codeView(sender: SwiftyCodeView, didFinishInput code: String)
+    func codeViewIsNotFull()
 }
 
 @IBDesignable
@@ -132,6 +133,7 @@ extension SwiftyCodeView: UITextFieldDelegate, SwiftyCodeTextFieldDelegate {
 			}
 
 			let prevItem = stackView.arrangedSubviews[i-1] as! SwiftyCodeItemView
+            delegate?.codeViewIsNotFull() // Added Line
 			if itemView.textField.text?.isEmpty ?? true {
 				prevItem.textField.text = ""
 				_ = prevItem.becomeFirstResponder()

--- a/SwiftyCodeViewDemo/SwiftyCodeViewDemo/ViewController.swift
+++ b/SwiftyCodeViewDemo/SwiftyCodeViewDemo/ViewController.swift
@@ -17,6 +17,12 @@ class ViewController: UIViewController {
 }
 
 extension ViewController: SwiftyCodeViewDelegate {
+    func codeViewIsNotFull() {
+        let alert = UIAlertController(title: "Error", message: "Enter Code", preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "Ok", style: .default, handler: nil))
+        present(alert, animated: true, completion: nil)
+    }
+    
     func codeView(sender: SwiftyCodeView, didFinishInput code: String) {
         resultLabel.text = code
     }


### PR DESCRIPTION
A new method called viewCodeIsNotFull() added to SwiftyCodeViewDelegate called when the user fills the code view then backward, may be used to disable some buttons when ViewCode is not full